### PR TITLE
fail correctly on single quote parsing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ Changelog
   the way string was grouped in general
 - fix: better number parsing handling, everything isn't fixed yet
 - make all (expected) errors inherit from the same BaronError class
+- fix: parsing fails correctly if a quoted string is not closed
 
 0.6 (2014-12-11)
 ----------------

--- a/tests/test_baron.py
+++ b/tests/test_baron.py
@@ -35,3 +35,12 @@ def test_error_untreated_error():
     with pytest.raises(BaronError):
         parse("?")
 
+
+def test_missing_quote_yields_error():
+    with pytest.raises(UntreatedError):
+        parse("'")
+    with pytest.raises(UntreatedError):
+        parse("'\n")
+    with pytest.raises(UntreatedError):
+        parse("'\n")
+

--- a/tests/test_spliter.py
+++ b/tests/test_spliter.py
@@ -2,8 +2,9 @@
 # -*- coding:Utf-8 -*-
 
 
-from baron.spliter import split
+from baron.spliter import split, UntreatedError
 from baron.utils import python_version
+import pytest
 
 
 def test_empty():
@@ -319,6 +320,20 @@ def test_multi_string():
 
 def test_multi_string_other_quotes():
     assert split('"""pouet pouet"""') == ['"""pouet pouet"""']
+
+
+def test_missing_quote_yields_error():
+    with pytest.raises(UntreatedError):
+        split("'")
+
+    with pytest.raises(UntreatedError):
+        split("'''")
+
+    with pytest.raises(UntreatedError):
+        split('"')
+
+    with pytest.raises(UntreatedError):
+        split('"""')
 
 
 def test_escape():


### PR DESCRIPTION
This fixes the following inconsistency:

```python
RedBaron("'").dumps() == RedBaron("").dumps() == ""
```