### PR TITLE
make all errors inherit from BaronError

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ Changelog
   surrounding it (for string chains), this ends up creating an inconsistancy in
   the way string was grouped in general
 - fix: better number parsing handling, everything isn't fixed yet
+- make all (expected) errors inherit from the same BaronError class
 
 0.6 (2014-12-11)
 ----------------

--- a/baron/formatting_grouper.py
+++ b/baron/formatting_grouper.py
@@ -1,6 +1,6 @@
-from .utils import FlexibleIterator
+from .utils import FlexibleIterator, BaronError
 
-class UnExpectedSpaceToken(Exception):
+class UnExpectedSpaceToken(BaronError):
     pass
 
 PRIORITY_ORDER = (

--- a/baron/tokenizer.py
+++ b/baron/tokenizer.py
@@ -1,7 +1,8 @@
 import re
+from .utils import BaronError
 
 
-class UnknowItem(Exception):
+class UnknowItem(BaronError):
     pass
 
 KEYWORDS = ("and", "as", "assert", "break", "class", "continue", "def", "del", "elif", "else", "except", "exec", "finally", "for", "from", "global", "if", "import", "in", "is", "lambda", "not", "or", "pass", "print", "raise", "return", "try", "while", "with", "yield")

--- a/tests/test_baron.py
+++ b/tests/test_baron.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from baron import parse, ParsingError, UnExpectedFormattingToken, GroupingError, UntreatedError
+from baron import parse, BaronError, ParsingError, UnExpectedFormattingToken, GroupingError, UntreatedError
 import pytest
 
 
@@ -11,18 +11,27 @@ def test_dummy_parse():
 def test_error_parsing_error():
     with pytest.raises(ParsingError):
         parse("(")
+    with pytest.raises(BaronError):
+        parse("(")
 
 
 def test_error_unexpected_formatting():
     with pytest.raises(UnExpectedFormattingToken):
+        parse("   a\nb")
+    with pytest.raises(BaronError):
         parse("   a\nb")
 
 
 def test_error_grouping():
     with pytest.raises(GroupingError):
         parse("   (a\n b")
+    with pytest.raises(BaronError):
+        parse("   (a\n b")
 
 
 def test_error_untreated_error():
     with pytest.raises(UntreatedError):
         parse("?")
+    with pytest.raises(BaronError):
+        parse("?")
+


### PR DESCRIPTION
This makes it easier to catch them.