### PR TITLE
[fix] remediate race when creating cache file

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Changelog
 
 0.6.2 (unreleased)
 
+- fix race condition when generating parser cache file
 - make all user-facing errors inherit from the same BaronError class
 
 0.6.1 (2015-01-31)

--- a/baron/parser.py
+++ b/baron/parser.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import json
 import stat
@@ -74,9 +75,14 @@ class BaronParserGenerator(ParserGenerator):
                     table = LRTable.from_cache(g, data)
         if table is None:
             table = LRTable.from_grammar(g)
-            fd = os.open(cache_file, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o0600)
-            with os.fdopen(fd, "w") as f:
-                json.dump(self.serialize_table(table), f)
+            try:
+                fd = os.open(cache_file, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o0600)
+            except OSError as e:
+                if e.errno != errno.EEXIST:
+                    raise
+            else:
+                with os.fdopen(fd, "w") as f:
+                    json.dump(self.serialize_table(table), f)
         # meh :(
         #if table.sr_conflicts:
             #warnings.warn(


### PR DESCRIPTION
If another process writes the cache file while we were generating the grammar, we'll fail to run os.open(cache_file, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o0600) because the file (now) exists.